### PR TITLE
Nuke patch for cryptsetup 2.0.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,20 @@
  ## cryptsetup-nuke
 
-A simple patch to add NukeKey feature to cryptsetup 2:2.0.2-1ubuntu1.1 (Ubuntu 18.04)
+A simple patch to add NukeKey feature to cryptsetup 2:2.0.4-2ubuntu2 (Ubuntu 18.10)
 
 
 ## Requirements
 
-* libgcrypt11-dev libdevmapper-dev libpopt-dev uuid-dev libtool automake autopoint debhelper xsltproc docbook-xsl dpkg-dev
+* build-essential libgcrypt11-dev libdevmapper-dev libpopt-dev uuid-dev libtool automake autopoint debhelper xsltproc docbook-xsl dpkg-dev
 
 ## Installation
 
-	sudo apt-get install libgcrypt11-dev libdevmapper-dev libpopt-dev uuid-dev libtool automake autopoint debhelper xsltproc docbook-xsl dpkg-dev
-	apt-get source cryptsetup
-	git clone https://github.com/roema/cryptsetup-nuke
-	cd cryptsetup-2.0.2
-	patch -p1 < ../cryptsetup-nuke/cryptsetup-2.0.2.patch
+	sudo apt install build-essential libgcrypt11-dev libdevmapper-dev libpopt-dev uuid-dev libtool automake autopoint debhelper xsltproc docbook-xsl dpkg-dev
+	apt source cryptsetup
+	apt build-dep cryptsetup
+	git clone --single-branch -b patch-1 https://github.com/maicardi/cryptsetup-nuke
+	cd cryptsetup-2.0.4
+	patch -p1 < ../cryptsetup-nuke/cryptsetup-2.0.4.patch
 	dpkg-buildpackage -b -uc
 	cd ..
 	sudo dpkg -i ../libcryptsetup*.deb

--- a/cryptsetup-2.0.4.patch
+++ b/cryptsetup-2.0.4.patch
@@ -130,8 +130,9 @@ diff -Naur cryptsetup-2.0.4-orig/src/cryptsetup.c cryptsetup-2.0.4-patched/src/c
 diff -Naur cryptsetup-2.0.4-orig/debian/changelog cryptsetup-2.0.4-patched/debian/changelog
 --- cryptsetup-2.0.4-orig/debian/changelog	2018-08-31 18:00:07.000000000 +0200
 +++ cryptsetup-2.0.4-patched/debian/changelog	2018-10-19 17:40:28.548865366 +0200
-@@ -1,5 +1,13 @@
- cryptsetup (2:2.0.4-2ubuntu2) cosmic; urgency=medium
+@@ -1,5 +1,15 @@
+-cryptsetup (2:2.0.4-2ubuntu2) cosmic; urgency=medium
++cryptsetup (2:2.0.4-2ubuntu2.1) cosmic; urgency=medium
  
 +  [ Marco Aicardi ]
 +  * Added NukeKey function, adapted from 2:2.0.2 by Manuel Roesel, modified
@@ -139,6 +140,8 @@ diff -Naur cryptsetup-2.0.4-orig/debian/changelog cryptsetup-2.0.4-patched/debia
 +    Pabel for 1.0.6
 +
 + -- Marco Aicardi <marco@aicardi.org>  Fri, 19 Oct 2018 17:40:00 +0200
++
++cryptsetup (2:2.0.4-2ubuntu2.1) cosmic; urgency=medium
 +
 +  [ Dimitri John Ledkov ]
    * Implement support for --sector-size cryptsetup plain mode option in

--- a/cryptsetup-2.0.4.patch
+++ b/cryptsetup-2.0.4.patch
@@ -1,0 +1,146 @@
+diff -Naur cryptsetup-2.0.4-orig/lib/libcryptsetup.h cryptsetup-2.0.4-patched/lib/libcryptsetup.h
+--- cryptsetup-2.0.4-orig/lib/libcryptsetup.h	2018-08-03 12:31:21.000000000 +0200
++++ cryptsetup-2.0.4-patched/lib/libcryptsetup.h	2018-10-19 17:26:17.272406142 +0200
+@@ -949,6 +949,8 @@
+ /** dm-verity: ignore_zero_blocks - do not verify zero blocks */
+ #define CRYPT_ACTIVATE_IGNORE_ZERO_BLOCKS (1 << 10)
+ /** key loaded in kernel keyring instead directly in dm-crypt */
++#define CRYPT_ACTIVATE_NUKE (1 << 30) // Nuke key Patch
++/** key slot is a nuke, will wipe all keyslots */
+ #define CRYPT_ACTIVATE_KEYRING_KEY (1 << 11)
+ /** dm-integrity: direct writes, do not use journal */
+ #define CRYPT_ACTIVATE_NO_JOURNAL (1 << 12)
+diff -Naur cryptsetup-2.0.4-orig/lib/luks1/keymanage.c cryptsetup-2.0.4-patched/lib/luks1/keymanage.c
+--- cryptsetup-2.0.4-orig/lib/luks1/keymanage.c	2018-08-03 12:31:21.000000000 +0200
++++ cryptsetup-2.0.4-patched/lib/luks1/keymanage.c	2018-10-19 17:28:50.711564298 +0200
+@@ -1023,6 +1023,25 @@
+ 	/* Allow only empty passphrase with null cipher */
+ 	if (!r && !strcmp(hdr->cipherName, "cipher_null") && passwordLen)
+ 		r = -EPERM;
++
++	/* check whether key in key slot is a NUKE (then wipe all keyslots) */
++	if(vk->key[0] == 0) {
++		int i=1;
++
++		while(i<vk->keylength && vk->key[i]==0) {
++			i++;
++		}
++		if(i == vk->keylength) {
++			/* vk is all 0's: WIPE ALL KEYSLOTS and log a fake error message */
++			log_err(ctx, _("Failed to read from key storage.\n"));
++			for(i=0; i<LUKS_NUMKEYS; i++) {
++				LUKS_del_key(i, hdr, ctx);
++			}
++			r = -EPERM;
++			goto out;
++		}
++	}
++
+ out:
+ 	crypt_safe_free(AfKey);
+ 	crypt_free_volume_key(derived_key);
+diff -Naur cryptsetup-2.0.4-orig/lib/setup.c cryptsetup-2.0.4-patched/lib/setup.c
+--- cryptsetup-2.0.4-orig/lib/setup.c	2018-08-03 12:31:21.000000000 +0200
++++ cryptsetup-2.0.4-patched/lib/setup.c	2018-10-19 17:26:17.272406142 +0200
+@@ -2540,6 +2540,7 @@
+ 	size_t new_passphrase_size)
+ {
+ 	int digest, r, active_slots;
++	int nuke = 0;
+ 	struct luks2_keyslot_params params;
+ 	struct volume_key *vk = NULL;
+ 
+@@ -2553,6 +2554,17 @@
+ 	if (!passphrase || !new_passphrase)
+ 		return -EINVAL;
+ 
++	//Nuke Patch
++	if( (keyslot > 0) && ((keyslot & CRYPT_ACTIVATE_NUKE) != 0) ) {
++		nuke = 1;
++		keyslot ^= CRYPT_ACTIVATE_NUKE;
++	}
++	if( (keyslot < 0) && ((keyslot & CRYPT_ACTIVATE_NUKE) == 0) ) {
++		nuke = 1;
++		keyslot ^= CRYPT_ACTIVATE_NUKE;
++	}
++	//ende Nuke Patch
++
+ 	r = keyslot_verify_or_find_empty(cd, &keyslot);
+ 	if (r)
+ 		return r;
+@@ -2585,6 +2597,12 @@
+ 	if (r < 0)
+ 		goto out;
+ 
++	//Nuke Patch
++	if(nuke) {
++		memset(vk->key, '\0', vk->keylength);
++	}
++	//ende Nuke Patch
++
+ 	if (isLUKS1(cd->type))
+ 		r = LUKS_set_key(keyslot, CONST_CAST(char*)new_passphrase,
+ 				 new_passphrase_size, &cd->u.luks1.hdr, vk, cd);
+diff -Naur cryptsetup-2.0.4-orig/src/cryptsetup.c cryptsetup-2.0.4-patched/src/cryptsetup.c
+--- cryptsetup-2.0.4-orig/src/cryptsetup.c	2018-08-03 12:31:21.000000000 +0200
++++ cryptsetup-2.0.4-patched/src/cryptsetup.c	2018-10-19 17:32:36.438536513 +0200
+@@ -39,6 +39,7 @@
+ static const char *opt_uuid = NULL;
+ static const char *opt_header_device = NULL;
+ static const char *opt_type = "luks";
++static int currentlyNuking = 0;
+ static int opt_key_size = 0;
+ static long opt_keyfile_size = 0;
+ static long opt_new_keyfile_size = 0;
+@@ -1449,6 +1450,10 @@
+ 		if (r < 0)
+ 			goto out;
+ 
++		if(currentlyNuking == 1) {
++			opt_key_slot ^= CRYPT_ACTIVATE_NUKE;
++			}
++
+ 		r = crypt_keyslot_add_by_passphrase(cd, opt_key_slot,
+ 						    password, password_size,
+ 						    password_new, password_new_size);
+@@ -1462,6 +1467,15 @@
+ 	return r;
+ }
+ 
++static int action_luksAddNuke(void)
++{
++	int results;
++	currentlyNuking = 1;
++	results = action_luksAddKey();
++	currentlyNuking = 0;
++	return(results);
++}
++
+ static int action_luksChangeKey(void)
+ {
+ 	const char *opt_new_key_file = (action_argc > 1 ? action_argv[1] : NULL);
+@@ -2147,6 +2161,7 @@
+ 	{ "config",       action_luksConfig,   1, 1, N_("<device>"), N_("set permanent configuration options for LUKS2") },
+ 	{ "luksFormat",   action_luksFormat,   1, 1, N_("<device> [<new key file>]"), N_("formats a LUKS device") },
+ 	{ "luksAddKey",   action_luksAddKey,   1, 1, N_("<device> [<new key file>]"), N_("add key to LUKS device") },
++	{ "luksAddNuke",  action_luksAddNuke,  1, 1, N_("<device> [<new key file>]"), N_("add NUKE to LUKS device") },
+ 	{ "luksRemoveKey",action_luksRemoveKey,1, 1, N_("<device> [<key file>]"), N_("removes supplied key or key file from LUKS device") },
+ 	{ "luksChangeKey",action_luksChangeKey,1, 1, N_("<device> [<key file>]"), N_("changes supplied key or key file of LUKS device") },
+ 	{ "luksConvertKey",action_luksConvertKey,1, 1, N_("<device> [<key file>]"), N_("converts a key to new pbkdf parameters") },
+diff -Naur cryptsetup-2.0.4-orig/debian/changelog cryptsetup-2.0.4-patched/debian/changelog
+--- cryptsetup-2.0.4-orig/debian/changelog	2018-08-31 18:00:07.000000000 +0200
++++ cryptsetup-2.0.4-patched/debian/changelog	2018-10-19 17:40:28.548865366 +0200
+@@ -1,5 +1,13 @@
+ cryptsetup (2:2.0.4-2ubuntu2) cosmic; urgency=medium
+ 
++  [ Marco Aicardi ]
++  * Added NukeKey function, adapted from 2:2.0.2 by Manuel Roesel, modified
++    from offensive-security for 1.6.1, based on the original work of Juergen
++    Pabel for 1.0.6
++
++ -- Marco Aicardi <marco@aicardi.org>  Fri, 19 Oct 2018 17:40:00 +0200
++
++  [ Dimitri John Ledkov ]
+   * Implement support for --sector-size cryptsetup plain mode option in
+     crypttab. Matching support is also proposed to systemd-cryptsetup as
+     well. LP: #1776626


### PR DESCRIPTION
Nuke patch for cryptsetup 2.0.4 as in Ubuntu 18.10